### PR TITLE
fixing ninja: error: '.so', needed by 'system/out/target/product/kmin…

### DIFF
--- a/smdk3470-common.mk
+++ b/smdk3470-common.mk
@@ -18,16 +18,16 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
 
 COMMON_PATH := device/samsung/smdk3470-common
 
+# Sound
+PRODUCT_PACKAGES += \
+    sound_trigger.primary.universal3470
+
 # Audio
 PRODUCT_PACKAGES := \
     audio.a2dp.default \
     audio.primary.universal3470 \
     audio.r_submix.default \
     audio.usb.default
-
-# Sound
-PRODUCT_PACKAGES += \
-    sound_trigger.primary.universal3470
 
 # needed by open-source audio-hal
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Fixing the following error, triggered for fresh builds of 14.1:

ninja: error: '.so', needed by 'system/out/target/product/kminilte/obj/SHARED_LIBRARIES/sound_trigger.primary.universal3470_intermediates/PACKED/sound_trigger.primary.universal3470.so', missing and no known rule to make it

